### PR TITLE
Change sha1 to sha265

### DIFF
--- a/msp430-elf-gcc.rb
+++ b/msp430-elf-gcc.rb
@@ -5,7 +5,7 @@ class Msp430ElfGcc < Formula
 
   url 'http://ftpmirror.gnu.org/gcc/gcc-4.9.2/gcc-4.9.2.tar.bz2'
   mirror 'ftp://gcc.gnu.org/pub/gcc/releases/gcc-4.9.2/gcc-4.9.2.tar.bz2'
-  sha1 '79dbcb09f44232822460d80b033c962c0237c6d8'
+  sha256 '2020c98295856aa13fda0f2f3a4794490757fc24bcca918d52cc8b4917b972dd'
 
   head 'svn://gcc.gnu.org/svn/gcc/branches/gcc-4_9-branch'
 


### PR DESCRIPTION
It appears sha1 is deprecated:

$ brew upgrade
Error: Calling Formula.sha1 is disabled!
Use Formula.sha256 instead.
/usr/local/Homebrew/Library/Taps/8bitsofme/homebrew-msp430/msp430-elf-gcc.rb:8:in `<class:Msp430ElfGcc>'
Please report this to the 8bitsofme/msp430 tap!