### PR TITLE
Formula.factory deprecated; use Formulary.factory

### DIFF
--- a/msp430-elf-gcc.rb
+++ b/msp430-elf-gcc.rb
@@ -16,7 +16,7 @@ class Msp430ElfGcc < Formula
 
   def install
     target = 'msp430-elf'
-    binutils = Formula.factory "#{target}-binutils"
+    binutils = Formulary.factory "#{target}-binutils"
     ENV['PATH'] += ":#{binutils.bin}:#{bin}"
 
     languages = %w[c c++]
@@ -41,7 +41,7 @@ class Msp430ElfGcc < Formula
       system 'make', 'install-host'
     end
 
-    newlib = Formula.factory "#{target}-newlib"
+    newlib = Formulary.factory "#{target}-newlib"
     newlib.brew do
       system 'mkdir', '-p', "#{HOMEBREW_LOGS}/#{newlib.name}"
       newlib_args = [


### PR DESCRIPTION
$ brew reinstall 8bitsofme/msp430/msp430-elf-gcc
==> Reinstalling 8bitsofme/msp430/msp430-elf-gcc
==> Cloning svn://gcc.gnu.org/svn/gcc/branches/gcc-4_9-branch
Updating /<home>/Library/Caches/Homebrew/msp430-elf-gcc--svn-HEAD
==> ../configure --target=msp430-elf --prefix=/usr/local/Cellar/msp430-elf-gcc/HEAD- --enable-languages=c,c++ --program-prefix=msp430-elf- --disable-nls --with-newlib --with
==> make all-host
==> make install-host
Warning: Calling Formula.factory is deprecated!
Use Formulary.factory instead.
/usr/local/Homebrew/Library/Taps/8bitsofme/homebrew-msp430/msp430-elf-gcc.rb:45:in `install'
Please report this to the 8bitsofme/msp430 tap!